### PR TITLE
allow 0 to be interpolated into css string

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ export default (strings, ...values) => {
   // ---------------------------------------
 
   // Zip constant string parts with any interpolated dynamic values
-  const str = strings.reduce((acc, string, i) => acc += string + (values[i] || ''), '')
+  const str = strings.reduce((acc, string, i) => acc += string + (values[i] == null ? '' : values[i]), '')
   // Use a hash of the ruleset as the uid
   const className = 'csz-' + hash(str)
   if(!cache[className]) {


### PR DESCRIPTION
Fixes this:
```js
const num = 0
csz`padding-top: ${num}px`
```
Currently outputs:
![image](https://user-images.githubusercontent.com/848652/54439915-222e0180-4710-11e9-9665-e19c17a493c5.png)
