### PR TITLE
Custom class names and counter based namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,21 @@ The package is designed to be used as an ES module. You can import it directly f
 ```js
 import css from 'https://unpkg.com/csz'
 
-// generate class name for ruleset
-const static = css`.my-class { background: blue; }` //.my-class-1
+// generate prefedined class name for ruleset 
+const static = css`.my-class background: blue;` //my-class-1
 
-// The custom class name and enclosing {} are both optional
-const static = css`background: blue;` //.csz-2
+// generate default class name for ruleset
+const static = css`background: blue;` //csz-2
 
 // generate class name for file contents
-const dynamic = css`/index.css` //.csz-3
+const dynamic = css`/index.css` //csz-3
 ```
 
-Both variations (static and dynamic) are sync and return a string in a format similar to `csz-b60d61b8`. If a ruleset is provided as a string then it is processed immediately but if a filepath is provided then processing is deferred until the contents of the file has been fetched.
+Both variations (static and dynamic) are sync and return a string in a format similar to `csz-1`. If a ruleset is provided as a string then it is processed immediately but if a filepath is provided then processing is deferred until the contents of the file has been fetched.
 
 > All file paths must start with a `/` and be absolute (relative to the current hostname) so if you are running your app on `example.com` and require `/styles/index.css` then csz will try fetch it from `example.com/styles/index.css`.
+
+> All predefined class names must start with `.` to generate class names with the format `my-class-2`
 
 Styles imported from a file are inevitably going to take some amount of time to download. Whilst the stylesheet is being downloaded a temporary ruleset is applied to the element which hides it (using `display: none`) until the fetched files have been processed. This was implemented to prevent flashes of unstyled content.
 
@@ -91,16 +93,16 @@ See below for an example of what a raw ruleset might look like and how it looks 
   <summary>Example stylesheet (processed)</summary>
 
   ```scss
-    .csz-a4B7ccH9 {font-size: 2em;}
+    .csz-1 {font-size: 2em;}
 
     body {background:red}
     h1 h2 h3 {content: 'nesting'}
 
     @media (max-width: 600px) {
-      .csz-a4B7ccH9 {display:none}
+      .csz-1 {display:none}
     }
 
-    .csz-a4B7ccH9:before {
+    .csz-1:before {
       -webkit-animation: slide-id 3s ease infinite;
       animation: slide-id 3s ease infinite;
     }
@@ -115,17 +117,17 @@ See below for an example of what a raw ruleset might look like and how it looks 
       to { opacity: 1}
     }
 
-    .csz-a4B7ccH9 {
+    .csz-1 {
       display:-webkit-box;
       display:-webkit-flex;
       display:-ms-flexbox;
       display:flex;
     }
 
-    .csz-a4B7ccH9::-webkit-input-placeholder {color:red;}
-    .csz-a4B7ccH9::-moz-placeholder {color:red;}
-    .csz-a4B7ccH9:-ms-input-placeholder {color:red;}
-    .csz-a4B7ccH9::placeholder {color:red;}
+    .csz-1::-webkit-input-placeholder {color:red;}
+    .csz-1::-moz-placeholder {color:red;}
+    .csz-1:-ms-input-placeholder {color:red;}
+    .csz-1::placeholder {color:red;}
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ The package is designed to be used as an ES module. You can import it directly f
 import css from 'https://unpkg.com/csz'
 
 // generate class name for ruleset
+const static = css`.my-class { background: blue; }` //.my-class-1
+
 // The custom class name and enclosing {} are both optional
-const static = css`.my-class { background: blue; }` 
+const static = css`background: blue;` //.csz-2
 
 // generate class name for file contents
-const dynamic = css`/index.css` 
+const dynamic = css`/index.css` //.csz-3
 ```
 
 Both variations (static and dynamic) are sync and return a string in a format similar to `csz-b60d61b8`. If a ruleset is provided as a string then it is processed immediately but if a filepath is provided then processing is deferred until the contents of the file has been fetched.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Importing styles dynamically is also supported (currently an experimental featur
 - Efficient caching of styles
 - Import styles from regular `.css` files
 - Available as an ES module (from [unpkg.com](https://unpkg.com/csz))
-- Unique class name generation and namespacing `.csz-lur7p80ssnq`
+- Custom class names with unique namespacing `.csz-1` or `.my-class-2`
 - Global style injection `:global(selector)`
 - Nested selectors `a { &:hover {} }`
 - Vendor prefixing `-moz-placeholder`
@@ -26,8 +26,12 @@ The package is designed to be used as an ES module. You can import it directly f
 ```js
 import css from 'https://unpkg.com/csz'
 
-const static = css`background: blue;` // generate class name for ruleset
-const dynamic = css`/index.css` // generate class name for file contents
+// generate class name for ruleset
+// The custom class name and enclosing {} are both optional
+const static = css`.my-class { background: blue; }` 
+
+// generate class name for file contents
+const dynamic = css`/index.css` 
 ```
 
 Both variations (static and dynamic) are sync and return a string in a format similar to `csz-b60d61b8`. If a ruleset is provided as a string then it is processed immediately but if a filepath is provided then processing is deferred until the contents of the file has been fetched.
@@ -136,7 +140,7 @@ export default () => {
     <div
       className={toggle
         ? css`/index.css`
-        : css`background: blue;`}
+        : css`.my-class background: blue;`}
     >
       <h1>Hello World!</h1>
       <button onClick={e => setToggle(!toggle)}>Toggle</button>

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ export default (strings, ...values) => {
   const className = [(classPrefix || "csz"), '-', cszCounter++].join('')
   const key = strings[0].startsWith('/')
     ? strings[0]
-    : strings.slice(1).reduce(
+    : [ruleStart].concat(strings.slice(1)).reduce(
       (acc, string, i) =>
         (acc += string + (values[i] || '')),
-      ruleStart + (values[0] || '')
+      ''
     )
 
   if (cache[key]) return cache[key].className

--- a/index.js
+++ b/index.js
@@ -1,38 +1,36 @@
 import stylis from './stylis.js'
 
 const cache = {}
-const hash = () =>
-  Math.random()
-    .toString(36)
-    .replace('0.', '')
+let cszCounter = 0
 
 const sheet = document.createElement('style')
 document.head.appendChild(sheet)
 
-const none = hash => `.${hash}{display:none}`
-const hide = hash => (sheet.innerHTML = none(hash) + sheet.innerHTML)
-const show = hash => (sheet.innerHTML = sheet.innerHTML.replace(none(hash), ''))
+const none = className => `.${className}{display:none}`
+const hide = className => (sheet.innerHTML = none(className) + sheet.innerHTML)
+const show = className => (sheet.innerHTML = sheet.innerHTML.replace(none(className), ''))
 
-const process = key => hash => rules => {
-  if (key.startsWith('/')) show(hash)
+const process = key => className => rules => {
+  if (key.startsWith('/')) show(className)
   sheet.innerHTML += (cache[key] = {
-    hash,
-    rules: stylis()(`.${hash}`, rules),
+    className,
+    rules: stylis()(`.${className}`, rules),
   }).rules
 }
 
 export default (strings, ...values) => {
+  const classPrefix = strings[0].startsWith('.') ? strings[0].substring(1, strings[0].indexOf(' ')) : "csz-"
   const key = strings[0].startsWith('/')
     ? strings[0]
     : strings.reduce(
-        (acc, string, i) =>
-          (acc += string + (values[i] == null ? '' : values[i])),
-        ''
-      )
+      (acc, string, i) =>
+        (acc += string + (values[i] == null ? '' : values[i])),
+      ''
+    )
 
-  if (cache[key]) return cache[key].hash
+  if (cache[key]) return cache[key].className
 
-  const className = 'csz-' + hash()
+  const className = (classPrefix.charAt(--classPrefix.length) === '-' ? classPrefix : classPrefix + '-') + cszCounter++
   const append = process(key)(className)
 
   if (key.startsWith('/')) {
@@ -40,6 +38,11 @@ export default (strings, ...values) => {
     fetch(key)
       .then(res => res.text())
       .then(append)
+  } else if (key.startsWith('.')) {
+    // Below supports both csz`.my-class { background: blue; }` Or csz`.my-class background: blue;`
+    const ruleStart = key.indexOf(' ') === key.replace(' ', '').indexOf('{') ? key.indexOf('{') : key.indexOf(' ')
+    const ruleEnd = key.trim().lastIndexOf('}') === key.length - 1 ? key.lastIndexOf('}') : key.length
+    append(key.substring(ruleStart + 1, ruleEnd))
   } else append(key)
 
   return className

--- a/index.js
+++ b/index.js
@@ -21,13 +21,12 @@ const process = key => className => rules => {
 export default (strings, ...values) => {
   const [, classSubstr, classPrefix] = strings[0].match(/^(\.(\S+)\s*)?.+/)
   const className = [(classPrefix || "csz"), '-', cszCounter++].join('')
-  const rules = [classPrefix ? strings[0].substring(classSubstr.length) : strings[0]].concat(strings.slice(1))
   const key = strings[0].startsWith('/')
     ? strings[0]
-    : rules.reduce(
+    : strings.slice(1).reduce(
       (acc, string, i) =>
-        (acc += string + (values[i] == null ? '' : values[i])),
-      ''
+        (acc += string + (values[i] || '')),
+      (classPrefix ? strings[0].substring(classSubstr.length) : strings[0]) + (values[0] || '')
     )
 
   if (cache[key]) return cache[key].className

--- a/index.js
+++ b/index.js
@@ -19,18 +19,18 @@ const process = key => className => rules => {
 }
 
 export default (strings, ...values) => {
-  const classPrefix = strings[0].startsWith('.') ? strings[0].substring(1, strings[0].indexOf(' ')) : "csz-"
+  const [, classSubstr, classPrefix] = strings[0].match(/^(\.(\S+)\s*)?.+/)
+  const className = [(classPrefix || "csz"), '-', cszCounter++].join('')
+  const rules = [classPrefix ? strings[0].substring(classSubstr.length) : strings[0]].concat(strings.slice(1))
   const key = strings[0].startsWith('/')
     ? strings[0]
-    : strings.reduce(
+    : rules.reduce(
       (acc, string, i) =>
         (acc += string + (values[i] == null ? '' : values[i])),
       ''
     )
 
   if (cache[key]) return cache[key].className
-
-  const className = (classPrefix.charAt(--classPrefix.length) === '-' ? classPrefix : classPrefix + '-') + cszCounter++
   const append = process(key)(className)
 
   if (key.startsWith('/')) {
@@ -38,11 +38,6 @@ export default (strings, ...values) => {
     fetch(key)
       .then(res => res.text())
       .then(append)
-  } else if (key.startsWith('.')) {
-    // Below supports both csz`.my-class { background: blue; }` Or csz`.my-class background: blue;`
-    const ruleStart = key.indexOf(' ') === key.replace(' ', '').indexOf('{') ? key.indexOf('{') : key.indexOf(' ')
-    const ruleEnd = key.trim().lastIndexOf('}') === key.length - 1 ? key.lastIndexOf('}') : key.length
-    append(key.substring(ruleStart + 1, ruleEnd))
   } else append(key)
 
   return className

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const process = key => className => rules => {
 }
 
 export default (strings, ...values) => {
-  const [, , classPrefix, ruleStart] = strings[0].match(/^(\.(\S+)\s*)?(\S.+)/)
+  const [, , classPrefix, ruleStart] = strings[0].match(/^(\.(\S+))?\s*(\S.+)/)
   const className = [(classPrefix || "csz"), '-', cszCounter++].join('')
   const key = strings[0].startsWith('/')
     ? strings[0]

--- a/index.js
+++ b/index.js
@@ -19,14 +19,14 @@ const process = key => className => rules => {
 }
 
 export default (strings, ...values) => {
-  const [, classSubstr, classPrefix] = strings[0].match(/^(\.(\S+)\s*)?.+/)
+  const [, , classPrefix, ruleStart] = strings[0].match(/^(\.(\S+)\s*)?(\S.+)/)
   const className = [(classPrefix || "csz"), '-', cszCounter++].join('')
   const key = strings[0].startsWith('/')
     ? strings[0]
     : strings.slice(1).reduce(
       (acc, string, i) =>
         (acc += string + (values[i] || '')),
-      (classPrefix ? strings[0].substring(classSubstr.length) : strings[0]) + (values[0] || '')
+      ruleStart + (values[0] || '')
     )
 
   if (cache[key]) return cache[key].className

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ const App = () => {
   return html`
     <div
       className=${toggle
-      ? css`.my-class-name
+      ? css`.my-class
             background: blue;
             & button {
               background: hotpink;

--- a/test/test.js
+++ b/test/test.js
@@ -8,13 +8,13 @@ const App = () => {
   return html`
     <div
       className=${toggle
-        ? css`
+      ? css`.my-class-name
             background: blue;
             & button {
               background: hotpink;
             }
           `
-        : css`/test/index.css`}
+      : css`/test/index.css`}
     >
       <h1>Hello World!</h1>
       <button className="btn" onClick=${e => setToggle(!toggle)}>Toggle</button>


### PR DESCRIPTION
closes #5 
closes #6 

Added support for custom css class names.
Default class name is .csz-# where # is a counter.

No more collisions. Faster. Easier to debug. 